### PR TITLE
Add missing `/` end tag & remove `save` from `npm install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install with your choice of package manager.
 ### NPM
 
 ```
-npm install gif-tsx --save
+npm install gif-tsx
 ```
 
 ### Yarn
@@ -79,7 +79,7 @@ function GifPlayer() {
     <div>
       <canvas {...canvasProps} ref={canvasRef} />
       <button alt="play" onClick={play} />
-      <button alt="pause" onClick={pause}>
+      <button alt="pause" onClick={pause} />
     </div>
   );
 }


### PR DESCRIPTION
The missing `/` on `button` took me too long to figure it out as Prettier was pointing somewhere else 😂 

And you don't need `save` on `npm install`. It's been the default for years now just like `yarn` :)