### PR TITLE
Update Handling of GIF Disposal Specifications to Work with Methods 2 and 3

### DIFF
--- a/src/hooks/useGifController.ts
+++ b/src/hooks/useGifController.ts
@@ -80,7 +80,7 @@ export function useGifController(
 
   type State = LoadingState | ResolvedState | ErrorState;
 
-  const ctx = canvas.current?.getContext("2d");
+  const ctx = canvas.current?.getContext("2d", { willReadFrequently: true });
 
   // asynchronous state variables strongly typed as a union such that properties
   // are only defined when `loading === true`.

--- a/src/lib/extractFrames.ts
+++ b/src/lib/extractFrames.ts
@@ -35,7 +35,7 @@ export function extractFrames(gifReader: GifReader): Frame[] | null {
   const canvas = document.createElement("canvas");
   canvas.width = width;
   canvas.height = height;
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
   if (!ctx) return null;
 
   for (let frameIndex = 0; frameIndex < gifReader.numFrames(); frameIndex++) {
@@ -54,7 +54,7 @@ export function extractFrames(gifReader: GifReader): Frame[] | null {
     const tempCanvas = document.createElement("canvas");
     tempCanvas.width = width;
     tempCanvas.height = height;
-    const tempCtx = tempCanvas.getContext("2d");
+    const tempCtx = tempCanvas.getContext("2d", { willReadFrequently: true });
     if (!tempCtx) return null;
 
     // extract GIF frame data to tempCanvas

--- a/src/lib/extractFrames.ts
+++ b/src/lib/extractFrames.ts
@@ -49,9 +49,6 @@ export function extractFrames(gifReader: GifReader): Frame[] | null {
       delay,
     } = gifReader.frameInfo(0);
 
-    // skip this frame if disposal >= 2; from GIF spec
-    if (disposal >= 2) continue;
-
     // create hidden temporary canvas that exists only to render the "diff"
     // between the previous frame and the current frame
     const tempCanvas = document.createElement("canvas");
@@ -73,10 +70,19 @@ export function extractFrames(gifReader: GifReader): Frame[] | null {
       dirtyHeight
     );
 
-    // draw the tempCanvas on top. ctx.putImageData(tempCtx.getImageData(...))
-    // is too primitive here, since the pixels would be *replaced* by incoming
-    // RGBA values instead of layered.
-    ctx.drawImage(tempCanvas, 0, 0);
+    // Disposal Method 1: Leave the current graphic in place and draw next frame
+    // on top of it.
+    if (disposal === 0 || disposal === 1) {
+      // draw the tempCanvas on top. ctx.putImageData(tempCtx.getImageData(...))
+      // is too primitive here, since the pixels would be *replaced* by incoming
+      // RGBA values instead of layered.
+      ctx.drawImage(tempCanvas, 0, 0);
+    } else if (disposal === 2) {
+      // Disposal Method 2: Restore to background color.
+      ctx.putImageData(tempCtx.getImageData(0, 0, dirtyWidth, dirtyHeight), 0, 0);
+    } else if (disposal === 3) {
+      // Disposal Method 3: don't draw anything new on top.
+    }
 
     frames.push({
       delay: delay * 10,


### PR DESCRIPTION
This updates the code to property handle GIF disposal methods 2 and 3 as outlined in [https://www.w3.org/Graphics/GIF/spec-gif89a.txt](https://www.w3.org/Graphics/GIF/spec-gif89a.txt).

Earlier, frames with a disposal method greater than or equal to 2 were discarded, while frames with a lower disposal number were drawn over the previous ones.

In this commit, the behavior remains the same for frames with a disposal number less than 2, but the following behavior is followed for those equal to or over 2:
 - 2: Clears frame and news draws next one
 - 3 and Greater: Does not draw anything on top of the frame and pushes it.

This also passes `{ willReadFrequently: true }` to all the getContext methods to remove the warnings. 